### PR TITLE
Maximizing requirements fails when you're sober

### DIFF
--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -412,7 +412,7 @@ export function meatOutfit(): void {
       ...(bjornalike ? new Map([[bjornalike, bjornValue(bjornFam)]]) : []),
     ]),
     preventEquip: $items`Buddy Bjorn, Crown of Thrones`.filter((bjorn) => bjorn !== bjornalike),
-    forceEquip: myInebriety() > inebrietyLimit() ? $items`Drunkula's wineglass` : undefined,
+    forceEquip: myInebriety() > inebrietyLimit() ? $items`Drunkula's wineglass` : [],
   }).maximize();
   if (haveEquipped($item`Buddy Bjorn`)) bjornifyFamiliar(bjornFam.familiar);
   else if (haveEquipped($item`Crown of Thrones`)) enthroneFamiliar(bjornFam.familiar);


### PR DESCRIPTION
Easy mistake to make, but explicit undefined vs "missing" undefined changes the behaviour of object spreading. It's the worst(?) bit of JS imo - people complain a lot but this is one of the only bits that truly doesn't make sense