### PR TITLE
fix: reset default grimoire preference

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -16,9 +16,9 @@ import { CandyTask, printHighlight, State } from "./lib";
 import { $familiar, $item, clamp, PropertiesManager, Session } from "libram";
 import args from "./args";
 
-export default class CandyEngine extends Engine<never, CandyTask> {
-  static propertyManager = new PropertiesManager();
+export const propertyManager = new PropertiesManager();
 
+export default class CandyEngine extends Engine<never, CandyTask> {
   session: Session;
   aaBossFlag: number;
 
@@ -31,12 +31,12 @@ export default class CandyEngine extends Engine<never, CandyTask> {
       )[0] === "checked"
         ? 1
         : 0;
-    this.propertyManager = CandyEngine.propertyManager;
     this.session = Session.current();
   }
 
   destruct(): void {
     super.destruct();
+    propertyManager.resetAll();
     visitUrl(
       `account.php?actions[]=flag_aabosses&flag_aabosses=${this.aaBossFlag}&action=Update`,
       true

--- a/src/wanderer/index.ts
+++ b/src/wanderer/index.ts
@@ -13,7 +13,7 @@ import {
 } from "./lib";
 import { lovebugsFactory } from "./lovebugs";
 import { yellowRayFactory } from "./yellowray";
-import CandyEngine from "../engine";
+import { propertyManager } from "../engine";
 import { printHighlight } from "../lib";
 
 export type { DraggableFight };
@@ -88,7 +88,7 @@ export function wanderWhere(
       [...locationSkiplist, ...badLocation]
     );
   } else {
-    CandyEngine.propertyManager.setChoices(unsupportedChoices.get(candidate.location) ?? {});
+    propertyManager.setChoices(unsupportedChoices.get(candidate.location) ?? {});
     const targets = candidate.targets.map((t) => t.name).join("; ");
     const value = candidate.value.toFixed(2);
     printHighlight(`Wandering at ${candidate.location} for expected value ${value} (${targets})`);


### PR DESCRIPTION
The `super(tasks);` call in the constructor instantiates grimoire's default `propertyManager` that the declared `propertyManager` was shadowing; this means that in the destructor, `super.destruct();` actually destroyed the shadowed one instead of the default one, and the defaultSettings in grimoire were assigned and never removed.

Among other things, this means that `logPreferenceChange` is set to true and never unset.

Move things around so that shouldn't happen.